### PR TITLE
some minor changes

### DIFF
--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -102,7 +102,6 @@ public:
 			} else {
 				if(bIsInitialized){
 					//ofSleepMillis(1.0/(float)frameRate);
-					ofLogError("waiting");
 					condition.wait(conditionMutex);
 				}else{
 					break;


### PR DESCRIPTION
frames.empty should not be called outside the lock
use condition instead of sleep (could be slower though)
use ofPixels::swapRgb, cleaner and slightly faster
