### PR TITLE
Non-blocking ffmpeg command

### DIFF
--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -249,7 +249,7 @@ bool ofxVideoRecorder::setupCustomOutput(int w, int h, float fps, int sampleRate
     else { // no video stream
         cmd << " -vn";
     }
-    cmd << " "+ outputString +"'";
+    cmd << " "+ outputString +"' &";
 
     //cerr << cmd.str();
 


### PR DESCRIPTION
For recording multiple videos at once. If the ffmpeg command is not run in the background, it will block additional pipes from being created.
