### PR TITLE
If not recording audio we sync the video against a 'system clock' (cf…

### DIFF
--- a/ofxVideoRecorderExample/src/testApp.cpp
+++ b/ofxVideoRecorderExample/src/testApp.cpp
@@ -84,6 +84,15 @@ void testApp::keyReleased(int key){
 //          vidRecorder.setup(fileName+ofGetTimestampString()+fileExt, vidGrabber.getWidth(), vidGrabber.getHeight(), 30); // no audio
 //            vidRecorder.setup(fileName+ofGetTimestampString()+fileExt, 0,0,0, sampleRate, channels); // no video
 //          vidRecorder.setupCustomOutput(vidGrabber.getWidth(), vidGrabber.getHeight(), 30, sampleRate, channels, "-vcodec mpeg4 -b 1600k -acodec mp2 -ab 128k -f mpegts udp://localhost:1234"); // for custom ffmpeg output string (streaming, etc)
+            
+            // Start recording
+            vidRecorder.start();
+        }
+        else if(!bRecording && vidRecorder.isInitialized()) {
+            vidRecorder.setPaused(true);
+        }
+        else if(bRecording && vidRecorder.isInitialized()) {
+            vidRecorder.setPaused(false);
         }
     }
     if(key=='c'){

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -361,7 +361,7 @@ void ofxVideoRecorder::start()
     bIsPaused = false;
     startTime = ofGetElapsedTimef();
 
-    cout << "Recording." << endl;
+    ofLogVerbose() << "Recording." << endl;
 }
 
 void ofxVideoRecorder::setPaused(bool bPause)
@@ -380,12 +380,12 @@ void ofxVideoRecorder::setPaused(bool bPause)
         totalRecordingDuration += recordingDuration;
 
         // Log
-        cout << "Paused." << endl;
+        ofLogVerbose() << "Paused." << endl;
     } else {
         startTime = ofGetElapsedTimef();
 
         // Log
-        cout << "Recording." << endl;
+        ofLogVerbose() << "Recording." << endl;
     }
 }
 

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -266,28 +266,28 @@ bool ofxVideoRecorder::setupCustomOutput(int w, int h, float fps, int sampleRate
 //        videoPipeFd = ::open(videoPipePath.c_str(), O_WRONLY);
         videoThread.setup(videoPipePath, &frames);
     }
-    
+
     bIsInitialized = true;
     bIsRecording = false;
     bIsPaused = false;
-    
+
     startTime = 0;
     recordingDuration = 0;
     totalRecordingDuration = 0;
-    
+
     return bIsInitialized;
 }
 
 void ofxVideoRecorder::addFrame(const ofPixels &pixels)
 {
     if (!bIsRecording || bIsPaused) return;
-    
+
     if(bIsInitialized && bRecordVideo)
     {
         int framesToAdd = 1; //default add one frame per request
-        
+
         if((bRecordAudio || bSysClockSync) && !bFinishing){
-            
+
             double syncDelta;
             double videoRecordedTime = videoFramesRecorded / frameRate;
 
@@ -302,7 +302,7 @@ void ofxVideoRecorder::addFrame(const ofPixels &pixels)
                 //this also handles incoming dynamic framerate while maintaining desired outgoing framerate
                 syncDelta = systemClock() - videoRecordedTime;
             }
-            
+
             if(syncDelta > 1.0/frameRate) {
                 //no enought video frames, we need to send extra video frames.
                 int numFramesCopied = 0;
@@ -318,7 +318,7 @@ void ofxVideoRecorder::addFrame(const ofPixels &pixels)
                 ofLogVerbose() << "ofxVideoRecorder: recDelta = " << syncDelta << ". Too many video frames, skipping.\n";
             }
         }
-        
+
         for(int i=0;i<framesToAdd;i++){
             //add desired number of frames
             frames.Produce(new ofPixels(pixels));
@@ -331,7 +331,7 @@ void ofxVideoRecorder::addFrame(const ofPixels &pixels)
 
 void ofxVideoRecorder::addAudioSamples(float *samples, int bufferSize, int numChannels){
     if (!bIsRecording || bIsPaused) return;
-    
+
     if(bIsInitialized && bRecordAudio){
         int size = bufferSize*numChannels;
         audioFrameShort * shortSamples = new audioFrameShort;
@@ -350,40 +350,40 @@ void ofxVideoRecorder::addAudioSamples(float *samples, int bufferSize, int numCh
 void ofxVideoRecorder::start()
 {
     if(!bIsInitialized) return;
-    
+
     if (bIsRecording) {
         //  We are already recording. No need to go further.
        return;
     }
-    
+
     // Start a recording.
     bIsRecording = true;
     bIsPaused = false;
     startTime = ofGetElapsedTimef();
-    
+
     cout << "Recording." << endl;
 }
 
 void ofxVideoRecorder::setPaused(bool bPause)
 {
     if(!bIsInitialized) return;
-    
+
     if (!bIsRecording || bIsPaused == bPause) {
         //  We are not recording or we are already paused. No need to go further.
         return;
     }
-    
+
     // Pause the recording
     bIsPaused = bPause;
-    
+
     if (bIsPaused) {
         totalRecordingDuration += recordingDuration;
-        
+
         // Log
         cout << "Paused." << endl;
     } else {
         startTime = ofGetElapsedTimef();
-        
+
         // Log
         cout << "Recording." << endl;
     }
@@ -392,7 +392,7 @@ void ofxVideoRecorder::setPaused(bool bPause)
 void ofxVideoRecorder::close()
 {
     if(!bIsInitialized) return;
-    
+
     bIsRecording = false;
 
     if(bRecordVideo && bRecordAudio) {
@@ -424,7 +424,7 @@ void ofxVideoRecorder::close()
             audioThread.signal();
         }
     }
-    
+
     //at this point all data that ffmpeg wants should have been consumed
     // one of the threads may still be trying to write a frame,
     // but once close() gets called they will exit the non_blocking write loop

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -95,9 +95,9 @@ class ofxVideoRecorder
 {
 public:
     ofxVideoRecorder();
-    bool setup(string fname, int w, int h, float fps, int sampleRate=0, int channels=0, bool silent=false);
-    bool setupCustomOutput(int w, int h, float fps, string outputString, bool silent=false);
-    bool setupCustomOutput(int w, int h, float fps, int sampleRate, int channels, string outputString, bool silent=false);
+    bool setup(string fname, int w, int h, float fps, int sampleRate=0, int channels=0, bool sysClockSync=false, bool silent=false);
+    bool setupCustomOutput(int w, int h, float fps, string outputString, bool sysClockSync=false, bool silent=false);
+    bool setupCustomOutput(int w, int h, float fps, int sampleRate, int channels, string outputString, bool sysClockSync=false, bool silent=false);
     void setQuality(ofImageQualityType q);
     void addFrame(const ofPixels &pixels);
     void addAudioSamples(float * samples, int bufferSize, int numChannels);
@@ -125,6 +125,7 @@ public:
     bool isInitialized(){ return bIsInitialized; }
     bool isRecording() { return bIsRecording; };
     bool isPaused() { return bIsPaused; };
+    bool isSyncAgainstSysClock() { return bSysClockSync; };
 
     string getMoviePath(){ return moviePath; }
     int getWidth(){return width;}
@@ -147,6 +148,7 @@ private:
     bool bFinishing;
     bool bIsSilent;
     
+    bool bSysClockSync;
     float startTime;
     float recordingDuration;
     float totalRecordingDuration;

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -101,7 +101,10 @@ public:
     void setQuality(ofImageQualityType q);
     void addFrame(const ofPixels &pixels);
     void addAudioSamples(float * samples, int bufferSize, int numChannels);
+    
+    void start();
     void close();
+    void setPaused(bool bPause);
 
     void setFfmpegLocation(string loc) { ffmpegLocation = loc; }
     void setVideoCodec(string codec) { videoCodec = codec; }
@@ -118,12 +121,15 @@ public:
 
     int getVideoQueueSize(){ return frames.size(); }
     int getAudioQueueSize(){ return audioFrames.size(); }
+    
     bool isInitialized(){ return bIsInitialized; }
+    bool isRecording() { return bIsRecording; };
+    bool isPaused() { return bIsPaused; };
 
     string getMoviePath(){ return moviePath; }
     int getWidth(){return width;}
     int getHeight(){return height;}
-
+    
 private:
     string fileName;
     string moviePath;
@@ -132,11 +138,20 @@ private:
     string videoCodec, audioCodec, videoBitrate, audioBitrate, pixelFormat;
     int width, height, sampleRate, audioChannels;
     float frameRate;
+    
     bool bIsInitialized;
     bool bRecordAudio;
     bool bRecordVideo;
+    bool bIsRecording;
+    bool bIsPaused;
     bool bFinishing;
     bool bIsSilent;
+    
+    float startTime;
+    float recordingDuration;
+    float totalRecordingDuration;
+    float systemClock();
+    
     lockFreeQueue<ofPixels *> frames;
     lockFreeQueue<audioFrameShort *> audioFrames;
     unsigned long long audioSamplesRecorded;

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -101,7 +101,7 @@ public:
     void setQuality(ofImageQualityType q);
     void addFrame(const ofPixels &pixels);
     void addAudioSamples(float * samples, int bufferSize, int numChannels);
-    
+
     void start();
     void close();
     void setPaused(bool bPause);
@@ -121,7 +121,7 @@ public:
 
     int getVideoQueueSize(){ return frames.size(); }
     int getAudioQueueSize(){ return audioFrames.size(); }
-    
+
     bool isInitialized(){ return bIsInitialized; }
     bool isRecording() { return bIsRecording; };
     bool isPaused() { return bIsPaused; };
@@ -130,7 +130,7 @@ public:
     string getMoviePath(){ return moviePath; }
     int getWidth(){return width;}
     int getHeight(){return height;}
-    
+
 private:
     string fileName;
     string moviePath;
@@ -139,7 +139,7 @@ private:
     string videoCodec, audioCodec, videoBitrate, audioBitrate, pixelFormat;
     int width, height, sampleRate, audioChannels;
     float frameRate;
-    
+
     bool bIsInitialized;
     bool bRecordAudio;
     bool bRecordVideo;
@@ -147,13 +147,13 @@ private:
     bool bIsPaused;
     bool bFinishing;
     bool bIsSilent;
-    
+
     bool bSysClockSync;
     float startTime;
     float recordingDuration;
     float totalRecordingDuration;
     float systemClock();
-    
+
     lockFreeQueue<ofPixels *> frames;
     lockFreeQueue<audioFrameShort *> audioFrames;
     unsigned long long audioSamplesRecorded;


### PR DESCRIPTION
… issue #13). Also added start() and setPaused() methods to be able to handle pauses while recording a video (vs the 'system clock'). Updated the example to show the uses of these 2 new methods.