### PR TITLE
Added some controls in ofxVideoDataWriterThread::threadedFunction() to avoid getting stuck in an infinity loop.

### DIFF
--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -67,7 +67,7 @@ void ofxVideoDataWriterThread::threadedFunction(){
             int b_offset = 0;
             int b_remaining = frame->getWidth()*frame->getHeight()*frame->getBytesPerPixel();
             
-            while(b_remaining > 0 || !isThreadRunning())
+            while(b_remaining > 0 && isThreadRunning())
             {
                 errno = 0;
                 

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -34,7 +34,7 @@ execThread::execThread(){
 
 void execThread::setup(string command){
     execCommand = command;
-    startThread(true, false);
+    startThread(true);
 }
 
 void execThread::threadedFunction(){
@@ -51,7 +51,7 @@ void ofxVideoDataWriterThread::setup(string filePath, lockFreeQueue<ofPixels *> 
     queue = q;
     bIsWriting = false;
     bClose = false;
-    startThread(true, false);
+    startThread(true);
 }
 
 void ofxVideoDataWriterThread::threadedFunction(){
@@ -110,7 +110,7 @@ void ofxAudioDataWriterThread::setup(string filePath, lockFreeQueue<audioFrameSh
     fd = -1;
     queue = q;
     bIsWriting = false;
-    startThread(true, false);
+    startThread(true);
 }
 
 void ofxAudioDataWriterThread::threadedFunction(){

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -67,7 +67,7 @@ void ofxVideoDataWriterThread::threadedFunction(){
             int b_offset = 0;
             int b_remaining = frame->getWidth()*frame->getHeight()*frame->getBytesPerPixel();
             
-            while(b_remaining > 0)
+            while(b_remaining > 0 || !isThreadRunning())
             {
                 errno = 0;
                 
@@ -76,15 +76,25 @@ void ofxVideoDataWriterThread::threadedFunction(){
                 if(b_written > 0){
                     b_remaining -= b_written;
                     b_offset += b_written;
+                    if (b_remaining != 0) {
+                        ofLogWarning("ofxVideoDataWriterThread") << ofGetTimestampString("%H:%M:%S:%i") << " - b_remaining is not 0 -> " << b_written << " - " << b_remaining << " - " << b_offset << ".";
+                        //break;
+                    }
                 }
                 else if (b_written < 0) {
-                    cout << ofGetTimestampString("%H:%M:%S:%i") << " - ##### ERROR: WRITE TO PIPE FAILED - " << errno << endl;
+                    ofLogError("ofxVideoDataWriterThread") << ofGetTimestampString("%H:%M:%S:%i") << " - write to PIPE failed with error -> " << errno << " - " << strerror(errno) << ".";
                     break;
                 }
                 else {
                     if(bClose){
+                        ofLogVerbose("ofxVideoDataWriterThread") << ofGetTimestampString("%H:%M:%S:%i") << " - Nothing was written and bClose is TRUE.";
                         break; // quit writing so we can close the file
                     }
+                    ofLogWarning("ofxVideoDataWriterThread") << ofGetTimestampString("%H:%M:%S:%i") << " - Nothing was written. Is this normal?";
+                }
+                
+                if (!isThreadRunning()) {
+                    ofLogWarning("ofxVideoDataWriterThread") << ofGetTimestampString("%H:%M:%S:%i") << " - The thread is not running anymore let's get out of here!";
                 }
             }
             bIsWriting = false;

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -66,12 +66,20 @@ void ofxVideoDataWriterThread::threadedFunction(){
             bIsWriting = true;
             int b_offset = 0;
             int b_remaining = frame->getWidth()*frame->getHeight()*frame->getBytesPerPixel();
+            
             while(b_remaining > 0)
             {
+                errno = 0;
+                
                 int b_written = ::write(fd, ((char *)frame->getPixels())+b_offset, b_remaining);
+                
                 if(b_written > 0){
                     b_remaining -= b_written;
                     b_offset += b_written;
+                }
+                else if (b_written < 0) {
+                    cout << ofGetTimestampString("%H:%M:%S:%i") << " - ##### ERROR: WRITE TO PIPE FAILED - " << errno << endl;
+                    break;
                 }
                 else {
                     if(bClose){


### PR DESCRIPTION
Hi,

I think I have found what was making my app crash. At least I found how to prevent the crash. 

If for some reasons the 'write' to the PIPE fails, we could get stuck in the 'while' loop. What happened to me that the 'write' returned error '9 - Bad file descriptor', nothing was written therefore the 'while' loop was infinite. The frames were added to the queue but never deleted, to a point too much memory was allocated, making the app crash.

