### PR TITLE
remove deprecated GLUT usage

### DIFF
--- a/ofxVideoRecorderExample/src/main.cpp
+++ b/ofxVideoRecorderExample/src/main.cpp
@@ -1,12 +1,10 @@
 #include "ofMain.h"
 #include "ofApp.h"
-#include "ofAppGlutWindow.h"
 
 //========================================================================
 int main( ){
 
-    ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 1024,768, OF_WINDOW);			// <-------- setup the GL context
+	ofSetupOpenGL(1024,768, OF_WINDOW);			// <-------- setup the GL context
 
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN


### PR DESCRIPTION
GLUT is deprecated in 0.9.0. I actually got errors with the old main.cpp of this example in oF0.9.0rc1 on Linux. Using the modern approach to create windows in oF fixed it.