### PR TITLE
If when closing there are frames in the queue, we deal with them in a separated thread.

### DIFF
--- a/ofxVideoRecorderExample/src/ofApp.cpp
+++ b/ofxVideoRecorderExample/src/ofApp.cpp
@@ -21,7 +21,7 @@ void ofApp::setup(){
     vidRecorder.setAudioCodec("mp3");
     vidRecorder.setAudioBitrate("192k");
     
-    ofAddListener(vidRecorder.outupFileCompleteEvent, this, &ofApp::recordingComplete);
+    ofAddListener(vidRecorder.outputFileCompleteEvent, this, &ofApp::recordingComplete);
 
 //    soundStream.listDevices();
 //    soundStream.setDeviceID(11);
@@ -33,7 +33,7 @@ void ofApp::setup(){
 }
 
 void ofApp::exit(){
-    ofRemoveListener(vidRecorder.outupFileCompleteEvent, this, &ofApp::recordingComplete);
+    ofRemoveListener(vidRecorder.outputFileCompleteEvent, this, &ofApp::recordingComplete);
     vidRecorder.close();
 }
 

--- a/ofxVideoRecorderExample/src/ofApp.cpp
+++ b/ofxVideoRecorderExample/src/ofApp.cpp
@@ -20,6 +20,8 @@ void ofApp::setup(){
     vidRecorder.setVideoBitrate("800k");
     vidRecorder.setAudioCodec("mp3");
     vidRecorder.setAudioBitrate("192k");
+    
+    ofAddListener(vidRecorder.outupFileCompleteEvent, this, &ofApp::recordingComplete);
 
 //    soundStream.listDevices();
 //    soundStream.setDeviceID(11);
@@ -30,7 +32,8 @@ void ofApp::setup(){
     ofEnableAlphaBlending();
 }
 
-void ofApp::exit() {
+void ofApp::exit(){
+    ofRemoveListener(vidRecorder.outupFileCompleteEvent, this, &ofApp::recordingComplete);
     vidRecorder.close();
 }
 
@@ -80,6 +83,10 @@ void ofApp::draw(){
 void ofApp::audioIn(float *input, int bufferSize, int nChannels){
     if(bRecording)
         vidRecorder.addAudioSamples(input, bufferSize, nChannels);
+}
+
+void ofApp::recordingComplete(ofxVideoRecorderOutputFileCompleteEventArgs& args){
+    cout << "The recoded video file is now complete." << endl;
 }
 
 //--------------------------------------------------------------

--- a/ofxVideoRecorderExample/src/ofApp.cpp
+++ b/ofxVideoRecorderExample/src/ofApp.cpp
@@ -32,6 +32,7 @@ void ofApp::setup(){
     ofEnableAlphaBlending();
 }
 
+//--------------------------------------------------------------
 void ofApp::exit(){
     ofRemoveListener(vidRecorder.outputFileCompleteEvent, this, &ofApp::recordingComplete);
     vidRecorder.close();
@@ -80,11 +81,13 @@ void ofApp::draw(){
     }
 }
 
+//--------------------------------------------------------------
 void ofApp::audioIn(float *input, int bufferSize, int nChannels){
     if(bRecording)
         vidRecorder.addAudioSamples(input, bufferSize, nChannels);
 }
 
+//--------------------------------------------------------------
 void ofApp::recordingComplete(ofxVideoRecorderOutputFileCompleteEventArgs& args){
     cout << "The recoded video file is now complete." << endl;
 }

--- a/ofxVideoRecorderExample/src/ofApp.h
+++ b/ofxVideoRecorderExample/src/ofApp.h
@@ -31,6 +31,8 @@ public:
     string fileName;
     string fileExt;
     
+    void recordingComplete(ofxVideoRecorderOutputFileCompleteEventArgs& args);
+    
     ofFbo recordFbo;
     ofPixels recordPixels;
 };

--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -549,7 +549,7 @@ void ofxVideoRecorder::outputFileComplete()
     // Notify the listeners.
     ofxVideoRecorderOutputFileCompleteEventArgs args;
     args.fileName = fileName;
-    ofNotifyEvent(outupFileCompleteEvent, args);
+    ofNotifyEvent(outputFileCompleteEvent, args);
 }
 
 //--------------------------------------------------------------

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -102,12 +102,27 @@ private:
     bool bClose;
 };
 
+
 //--------------------------------------------------------------
 //--------------------------------------------------------------
-class ofxVideoRecorder
+class ofxVideoRecorderVideoCompleteEventArgs
+: public ofEventArgs
+{
+public:
+    string fileName;
+};
+
+//--------------------------------------------------------------
+//--------------------------------------------------------------
+class ofxVideoRecorder  : public ofThread
 {
 public:
     ofxVideoRecorder();
+    
+    void threadedFunction();
+    
+    ofEvent<ofxVideoRecorderVideoCompleteEventArgs> videoCompleteEvent;
+    
     bool setup(string fname, int w, int h, float fps, int sampleRate=0, int channels=0, bool sysClockSync=false, bool silent=false);
     bool setupCustomOutput(int w, int h, float fps, string outputString, bool sysClockSync=false, bool silent=false);
     bool setupCustomOutput(int w, int h, float fps, int sampleRate, int channels, string outputString, bool sysClockSync=false, bool silent=false);
@@ -184,4 +199,6 @@ private:
     static set<int> openPipes;
     static int requestPipeNumber();
     static void retirePipeNumber(int num);
+    
+    void videoComplete();
 };

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -121,7 +121,7 @@ public:
     
     void threadedFunction();
     
-    ofEvent<ofxVideoRecorderOutputFileCompleteEventArgs> outupFileCompleteEvent;
+    ofEvent<ofxVideoRecorderOutputFileCompleteEventArgs> outputFileCompleteEvent;
     
     bool setup(string fname, int w, int h, float fps, int sampleRate=0, int channels=0, bool sysClockSync=false, bool silent=false);
     bool setupCustomOutput(int w, int h, float fps, string outputString, bool sysClockSync=false, bool silent=false);

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -105,7 +105,7 @@ private:
 
 //--------------------------------------------------------------
 //--------------------------------------------------------------
-class ofxVideoRecorderVideoCompleteEventArgs
+class ofxVideoRecorderOutputFileCompleteEventArgs
 : public ofEventArgs
 {
 public:
@@ -121,7 +121,7 @@ public:
     
     void threadedFunction();
     
-    ofEvent<ofxVideoRecorderVideoCompleteEventArgs> videoCompleteEvent;
+    ofEvent<ofxVideoRecorderOutputFileCompleteEventArgs> outupFileCompleteEvent;
     
     bool setup(string fname, int w, int h, float fps, int sampleRate=0, int channels=0, bool sysClockSync=false, bool silent=false);
     bool setupCustomOutput(int w, int h, float fps, string outputString, bool sysClockSync=false, bool silent=false);
@@ -200,5 +200,5 @@ private:
     static int requestPipeNumber();
     static void retirePipeNumber(int num);
     
-    void videoComplete();
+    void outputFileComplete();
 };


### PR DESCRIPTION
Hi,

I just worked on a project were the recording process was heavy, and therefore ofxVideoRecorder / ffmpeg was not able to keep up. As a result the queue of frames was increasing quickly. When the recording was stop the entire app was freezing until the queue was emptied (and sometime some of the frames were not written/saved). My solution was to go through the remaining frames in a separated thread. I did quite a lot of stress runs and it ran in production for few days without any issues.

Also, I'm not sure that the calls to 'setPipeNonBlocking()' are doing anything (at least on OS X).

Please let me know what you think of this.

Thanks.

