### PR TITLE
Added outputPixelFormat property

### DIFF
--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -228,6 +228,7 @@ ofxVideoRecorder::ofxVideoRecorder(){
     videoBitrate = "2000k";
     audioBitrate = "128k";
     pixelFormat = "rgb24";
+    outputPixelFormat = "";
 }
 
 //--------------------------------------------------------------
@@ -323,6 +324,8 @@ bool ofxVideoRecorder::setupCustomOutput(int w, int h, float fps, int sampleRate
     }
     if(bRecordVideo){ // video input options and file
         cmd << " -r "<< fps << " -s " << w << "x" << h << " -f rawvideo -pix_fmt " << pixelFormat <<" -i " << videoPipePath << " -r " << fps;
+        if (outputPixelFormat.length() > 0)
+            cmd << " -pix_fmt " << outputPixelFormat;
     }
     else { // no video stream
         cmd << " -vn";

--- a/src/ofxVideoRecorder.h
+++ b/src/ofxVideoRecorder.h
@@ -148,6 +148,9 @@ public:
     void setPixelFormat( string pixelF){ //rgb24 || gray, default is rgb24
         pixelFormat = pixelF;
     };
+    void setOutputPixelFormat(string pixelF) {
+        outputPixelFormat = pixelF;
+    }
 
     unsigned long long getNumVideoFramesRecorded() { return videoFramesRecorded; }
     unsigned long long getNumAudioSamplesRecorded() { return audioSamplesRecorded; }
@@ -169,7 +172,7 @@ private:
     string moviePath;
     string videoPipePath, audioPipePath;
     string ffmpegLocation;
-    string videoCodec, audioCodec, videoBitrate, audioBitrate, pixelFormat;
+    string videoCodec, audioCodec, videoBitrate, audioBitrate, pixelFormat, outputPixelFormat;
     int width, height, sampleRate, audioChannels;
     float frameRate;
 


### PR DESCRIPTION
I needed to set `yuv420p` pixel format for the generated video in order to be able to reproduced it in every player (specifically HTML5 players). To achieve this I decided to add an optional `outputPixelFormat` property with a setter. It's optional because `ffmpeg` automatically picks a pixel format if you don't provide the `-pix_fmt` param (which was not the one I needed).