### PR TITLE
fix mislabeled audio thread logger as video thread

### DIFF
--- a/src/ofxVideoRecorder.cpp
+++ b/src/ofxVideoRecorder.cpp
@@ -162,7 +162,7 @@ void ofxAudioDataWriterThread::threadedFunction(){
     if(fd == -1){
         ofLogVerbose("ofxAudioDataWriterThread") << "opening pipe: " <<  filePath;
         fd = ::open(filePath.c_str(), O_WRONLY);
-        ofLogWarning("ofxVideoDataWriterThread") << "got file descriptor " << fd;
+        ofLogWarning("ofxAudioDataWriterThread") << "got file descriptor " << fd;
     }
 
     while(isThreadRunning())


### PR DESCRIPTION
I'm actually looking for clues as to why your addon might not work on my machine, but so far I only found this insignificant mistake ;)